### PR TITLE
fizzBuzz-may-24-1

### DIFF
--- a/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/error.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/error.ts
@@ -1,0 +1,6 @@
+export class NumberOutOfRangeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'NumberOutOfRangeError';
+  }
+}

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/fizzbuzz.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/fizzbuzz.ts
@@ -1,4 +1,5 @@
 export function fizzBuzz(num: number) {
+  if (num === 15) return 'FizzBuzz';
   return num === 3 ? 'Fizz' : 'Buzz'; 
 }
 

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/fizzbuzz.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/fizzbuzz.ts
@@ -1,11 +1,12 @@
 export function fizzBuzz(num: number) {
   const isMultipleOfThree = num % 3 === 0; 
-  const isMultipleOfThreeAndFive = num % 3 === 0 && num % 5 == 0;
+  const isMultipleOfFive = num % 5 === 0; 
+  const isMultipleOfThreeAndFive = isMultipleOfThree && isMultipleOfFive;
 
 
   if (isMultipleOfThreeAndFive) return 'FizzBuzz';
   if (isMultipleOfThree) return 'Fizz';
-  if (num % 5 === 0) return 'Buzz'
+  if (isMultipleOfFive) return 'Buzz'
   return num.toString();
 }
 

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/fizzbuzz.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/fizzbuzz.ts
@@ -1,0 +1,4 @@
+export function fizzBuzz(num: number) {
+
+}
+

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/fizzbuzz.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/fizzbuzz.ts
@@ -2,7 +2,7 @@ export function fizzBuzz(num: number) {
   const isMultipleOfThree = num % 3 === 0; 
 
   if (num === 43) return "43";
-  if (num === 15 || num === 45) return 'FizzBuzz';
+  if (num === 15 || num === 45 || num === 90) return 'FizzBuzz';
   if (isMultipleOfThree) return 'Fizz';
   return 'Buzz'; 
 }

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/fizzbuzz.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/fizzbuzz.ts
@@ -1,8 +1,11 @@
 export function fizzBuzz(num: number) {
+  if (num > 100) {
+    throw new Error("Number argument should not exceed 100");
+  }
+
   const isMultipleOfThree = num % 3 === 0; 
   const isMultipleOfFive = num % 5 === 0; 
   const isMultipleOfThreeAndFive = isMultipleOfThree && isMultipleOfFive;
-
 
   if (isMultipleOfThreeAndFive) return 'FizzBuzz';
   if (isMultipleOfThree) return 'Fizz';

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/fizzbuzz.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/fizzbuzz.ts
@@ -3,6 +3,7 @@ export function fizzBuzz(num: number) {
   const isMultipleOfThreeAndFive = num % 3 === 0 && num % 5 == 0;
 
   if (num === 43) return "43";
+  if (num === 11) return "11";
   if (isMultipleOfThreeAndFive) return 'FizzBuzz';
   if (isMultipleOfThree) return 'Fizz';
   return 'Buzz'; 

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/fizzbuzz.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/fizzbuzz.ts
@@ -4,6 +4,7 @@ export function fizzBuzz(num: number) {
 
   if (num === 43) return "43";
   if (num === 11) return "11";
+  if (num === 23) return "23";
   if (isMultipleOfThreeAndFive) return 'FizzBuzz';
   if (isMultipleOfThree) return 'Fizz';
   return 'Buzz'; 

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/fizzbuzz.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/fizzbuzz.ts
@@ -3,6 +3,8 @@ export function fizzBuzz(num: number) {
     throw new Error("Number argument should not exceed 100");
   }
 
+  
+
   const isMultipleOfThree = num % 3 === 0; 
   const isMultipleOfFive = num % 5 === 0; 
   const isMultipleOfThreeAndFive = isMultipleOfThree && isMultipleOfFive;

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/fizzbuzz.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/fizzbuzz.ts
@@ -1,4 +1,4 @@
 export function fizzBuzz(num: number) {
-
+  return 'Fizz'; 
 }
 

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/fizzbuzz.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/fizzbuzz.ts
@@ -5,7 +5,7 @@ export function fizzBuzz(num: number) {
 
   if (isMultipleOfThreeAndFive) return 'FizzBuzz';
   if (isMultipleOfThree) return 'Fizz';
-  if (!isMultipleOfThree || !(num % 5 === 0)) return num.toString()
-  return 'Buzz';
+  if (num % 5 === 0) return 'Buzz'
+  return num.toString();
 }
 

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/fizzbuzz.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/fizzbuzz.ts
@@ -2,7 +2,7 @@ export function fizzBuzz(num: number) {
   const isMultipleOfThree = num % 3 === 0; 
 
   if (num === 43) return "43";
-  if (num === 15) return 'FizzBuzz';
+  if (num === 15 || num === 45) return 'FizzBuzz';
   if (isMultipleOfThree) return 'Fizz';
   return 'Buzz'; 
 }

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/fizzbuzz.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/fizzbuzz.ts
@@ -1,4 +1,5 @@
 export function fizzBuzz(num: number) {
+  if (num === 9) return 'Fizz';
   if (num === 15) return 'FizzBuzz';
   return num === 3 ? 'Fizz' : 'Buzz'; 
 }

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/fizzbuzz.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/fizzbuzz.ts
@@ -1,10 +1,12 @@
+import { NumberOutOfRangeError } from "./error";
+
 export function fizzBuzz(num: number) {
   if (num > 100) {
-    throw new Error("Number argument should not exceed 100");
+    throw new NumberOutOfRangeError("Number argument should not exceed 100");
   }
 
   if (num < 1) {
-    throw new Error("Number argument should be between 1 and 100");
+    throw new NumberOutOfRangeError("Number argument should not be less than 1");
   }
 
   const isMultipleOfThree = num % 3 === 0; 

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/fizzbuzz.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/fizzbuzz.ts
@@ -1,8 +1,9 @@
 export function fizzBuzz(num: number) {
   const isMultipleOfThree = num % 3 === 0; 
+  const isMultipleOfThreeAndFive = num % 3 === 0 && num % 5 == 0;
 
   if (num === 43) return "43";
-  if (num === 15 || num === 45 || num === 90) return 'FizzBuzz';
+  if (isMultipleOfThreeAndFive) return 'FizzBuzz';
   if (isMultipleOfThree) return 'Fizz';
   return 'Buzz'; 
 }

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/fizzbuzz.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/fizzbuzz.ts
@@ -1,6 +1,7 @@
 export function fizzBuzz(num: number) {
   const isMultipleOfThree = num % 3 === 0; 
 
+  if (num === 43) return "43";
   if (num === 15) return 'FizzBuzz';
   if (isMultipleOfThree) return 'Fizz';
   return 'Buzz'; 

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/fizzbuzz.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/fizzbuzz.ts
@@ -1,6 +1,8 @@
 export function fizzBuzz(num: number) {
-  if (num === 9) return 'Fizz';
+  const isMultipleOfThree = num % 3 === 0; 
+
   if (num === 15) return 'FizzBuzz';
-  return num === 3 ? 'Fizz' : 'Buzz'; 
+  if (isMultipleOfThree) return 'Fizz';
+  return 'Buzz'; 
 }
 

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/fizzbuzz.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/fizzbuzz.ts
@@ -1,4 +1,4 @@
 export function fizzBuzz(num: number) {
-  return 'Fizz'; 
+  return num === 3 ? 'Fizz' : 'Buzz'; 
 }
 

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/fizzbuzz.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/fizzbuzz.ts
@@ -3,7 +3,9 @@ export function fizzBuzz(num: number) {
     throw new Error("Number argument should not exceed 100");
   }
 
-  
+  if (num < 1) {
+    throw new Error("Number argument should be between 1 and 100");
+  }
 
   const isMultipleOfThree = num % 3 === 0; 
   const isMultipleOfFive = num % 5 === 0; 

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/fizzbuzz.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/fizzbuzz.ts
@@ -2,11 +2,10 @@ export function fizzBuzz(num: number) {
   const isMultipleOfThree = num % 3 === 0; 
   const isMultipleOfThreeAndFive = num % 3 === 0 && num % 5 == 0;
 
-  if (num === 43) return "43";
-  if (num === 11) return "11";
-  if (num === 23) return "23";
+
   if (isMultipleOfThreeAndFive) return 'FizzBuzz';
   if (isMultipleOfThree) return 'Fizz';
-  return 'Buzz'; 
+  if (!isMultipleOfThree || !(num % 5 === 0)) return num.toString()
+  return 'Buzz';
 }
 

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
@@ -24,6 +24,12 @@ describe("fizzbuzz", () => {
     expect(fizzBuzz(3)).toBe('Fizz');
   });
 
+  it('return "Buzz" for 5', () => {
+    expect(fizzBuzz(5)).toBe('Buzz');
+  });
+
   
+
+
 
 });

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
@@ -30,6 +30,10 @@ describe("fizzbuzz", () => {
     expect(fizzBuzz(5)).toBe('Buzz');
   });
 
+  it('returns "Buzz" for 25', () => {
+    expect(fizzBuzz(25)).toBe('Buzz');
+  })
+
   it('returns "FizzBuzz" for 15', () => {
     expect(fizzBuzz(15)).toBe('FizzBuzz');
   });

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
@@ -24,6 +24,14 @@ describe("fizzbuzz", () => {
     expect(fizzBuzz(3)).toBe('Fizz');
   });
 
+  it('returns "Fizz" for 6', () => {
+    expect(fizzBuzz(6)).toBe('Fizz');
+  });
+
+  it('returns "Fizz" for 9', () => {
+    expect(fizzBuzz(9)).toBe('Fizz');
+  });
+
   it('returns "Buzz" for 5', () => {
     expect(fizzBuzz(5)).toBe('Buzz');
   });
@@ -32,9 +40,6 @@ describe("fizzbuzz", () => {
     expect(fizzBuzz(15)).toBe('FizzBuzz');
   });
 
-  it('returns "Fizz" for 9', () => {
-    expect(fizzBuzz(9)).toBe('Fizz');
-  });
 
 
 

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
@@ -32,6 +32,10 @@ describe("fizzbuzz", () => {
     expect(fizzBuzz(15)).toBe('FizzBuzz');
   });
 
+  it('returns "Fizz" for 9', () => {
+    expect(fizzBuzz(9)).toBe('Fizz');
+  });
+
 
 
 });

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
@@ -46,6 +46,10 @@ describe("fizzbuzz", () => {
     expect(fizzBuzz(90)).toBe("FizzBuzz");
   })
 
+  it('returns "11" for 11', () => {
+    expect(fizzBuzz(11)).toBe("11");
+  })
+
   it('returns "43" for 43', () => {
     expect(fizzBuzz(43)).toBe("43");
   });

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
@@ -1,3 +1,4 @@
+import { NumberOutOfRangeError } from "./error";
 import { fizzBuzz } from "./fizzbuzz";
 
 /*
@@ -38,10 +39,10 @@ describe("fizzbuzz", () => {
   })  
 
   it('throws an error for numbers > 100', () => {
-    expect(() => fizzBuzz(102)).toThrow(new Error("Number argument should not exceed 100"));
+    expect(() => fizzBuzz(102)).toThrow(new NumberOutOfRangeError("Number argument should not exceed 100"));
   })
 
   it('throws an error for numbers < 1', () => {
-    expect(() => fizzBuzz(-3)).toThrow(/Number argument should be between 1 and 100/);
+    expect(() => fizzBuzz(-3)).toThrow(new NumberOutOfRangeError("Number argument should not be less than 1"));
   })
 });

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
@@ -38,5 +38,9 @@ describe("fizzbuzz", () => {
     expect(fizzBuzz(43)).toBe("43");
   });
 
+  it('returns "Fizz" for 42', () => {
+    expect(fizzBuzz(42)).toBe("Fizz")
+  })
+
   
 });

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
@@ -20,16 +20,10 @@ Grading Checklist
 
 */
 describe("fizzbuzz", () => {
-  it('returns "Fizz" for 3', () => {
-    expect(fizzBuzz(3)).toBe('Fizz');
-  });
-
-  it('returns "Fizz" for 6', () => {
-    expect(fizzBuzz(6)).toBe('Fizz');
-  });
-
-  it('returns "Fizz" for 9', () => {
-    expect(fizzBuzz(9)).toBe('Fizz');
+  it.each([ 3, 6, 9])(
+    "returns 'Fizz' for multiples of 3",
+    (value: number) => {
+      expect(fizzBuzz(value)).toBe('Fizz');
   });
 
   it('returns "Buzz" for 5', () => {
@@ -40,7 +34,9 @@ describe("fizzbuzz", () => {
     expect(fizzBuzz(15)).toBe('FizzBuzz');
   });
 
+  it('returns "43" for 43', () => {
+    expect(fizzBuzz(43)).toBe("43");
+  });
 
-
-
+  
 });

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
@@ -34,13 +34,17 @@ describe("fizzbuzz", () => {
     expect(fizzBuzz(15)).toBe('FizzBuzz');
   });
 
+  it('returns "FizzBuzz" for 45', () => {
+    expect(fizzBuzz(45)).toBe("FizzBuzz");
+  })
+
   it('returns "43" for 43', () => {
     expect(fizzBuzz(43)).toBe("43");
   });
 
   it('returns "Fizz" for 42', () => {
     expect(fizzBuzz(42)).toBe("Fizz")
-  })
+  });
 
   
 });

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
@@ -28,7 +28,9 @@ describe("fizzbuzz", () => {
     expect(fizzBuzz(5)).toBe('Buzz');
   });
 
-
+  it('returns "FizzBuzz" for 15', () => {
+    expect(fizzBuzz(15)).toBe('FizzBuzz');
+  });
 
 
 

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
@@ -38,7 +38,7 @@ describe("fizzbuzz", () => {
   })  
 
   it('throws an error for numbers > 100', () => {
-    expect(() => fizzBuzz(102)).toThrow();
+    expect(() => fizzBuzz(102)).toThrow(new Error("Number argument should not exceed 100"));
   })
 
   it('throws an error for numbers < 1', () => {

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
@@ -36,4 +36,8 @@ describe("fizzbuzz", () => {
   ])("returns $result for $input", ({input, result }) => {
     expect(fizzBuzz(input)).toBe(result);
   })  
+
+  it('throws an error for numbers over 100', () => {
+    expect(fizzBuzz(102)).toThrowError();
+  })
 });

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
@@ -37,7 +37,7 @@ describe("fizzbuzz", () => {
     expect(fizzBuzz(input)).toBe(result);
   })  
 
-  it('throws an error for numbers over 100', () => {
-    expect(fizzBuzz(102)).toThrowError();
+  it('throws an error for numbers > 100', () => {
+    expect(() => fizzBuzz(102)).toThrow();
   })
 });

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
@@ -50,6 +50,10 @@ describe("fizzbuzz", () => {
     expect(fizzBuzz(11)).toBe("11");
   })
 
+  it('returns "23" for 23', () => {
+    expect(fizzBuzz(23)).toBe("23");
+  })
+
   it('returns "43" for 43', () => {
     expect(fizzBuzz(43)).toBe("43");
   });

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
@@ -20,47 +20,20 @@ Grading Checklist
 
 */
 describe("fizzbuzz", () => {
-  it.each([ 3, 6, 9])(
-    "returns 'Fizz' for multiples of 3",
-    (value: number) => {
-      expect(fizzBuzz(value)).toBe('Fizz');
-  });
-
-  it('returns "Buzz" for 5', () => {
-    expect(fizzBuzz(5)).toBe('Buzz');
-  });
-
-  it('returns "Buzz" for 25', () => {
-    expect(fizzBuzz(25)).toBe('Buzz');
-  })
-
-  it('returns "FizzBuzz" for 15', () => {
-    expect(fizzBuzz(15)).toBe('FizzBuzz');
-  });
-
-  it('returns "FizzBuzz" for 45', () => {
-    expect(fizzBuzz(45)).toBe("FizzBuzz");
-  })
-
-  it('returns "FizzBuzz" for 90', () => {
-    expect(fizzBuzz(90)).toBe("FizzBuzz");
-  })
-
-  it('returns "11" for 11', () => {
-    expect(fizzBuzz(11)).toBe("11");
-  })
-
-  it('returns "23" for 23', () => {
-    expect(fizzBuzz(23)).toBe("23");
-  })
-
-  it('returns "43" for 43', () => {
-    expect(fizzBuzz(43)).toBe("43");
-  });
-
-  it('returns "Fizz" for 42', () => {
-    expect(fizzBuzz(42)).toBe("Fizz")
-  });
-
-  
+  it.each([
+    { input: 15, result: 'FizzBuzz' },
+    { input: 45, result: 'FizzBuzz' },
+    { input: 90, result: 'FizzBuzz' },
+    { input: 3, result: 'Fizz' },
+    { input: 6, result: 'Fizz' },
+    { input: 9, result: 'Fizz' },
+    { input: 5, result: 'Buzz' },
+    { input: 25, result: 'Buzz' },
+    { input: 50, result: 'Buzz' },
+    { input: 11, result: '11' },
+    { input: 23, result: '23' },
+    { input: 43, result: '43' },
+  ])("returns $result for $input", ({input, result }) => {
+    expect(fizzBuzz(input)).toBe(result);
+  })  
 });

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
@@ -42,6 +42,10 @@ describe("fizzbuzz", () => {
     expect(fizzBuzz(45)).toBe("FizzBuzz");
   })
 
+  it('returns "FizzBuzz" for 90', () => {
+    expect(fizzBuzz(90)).toBe("FizzBuzz");
+  })
+
   it('returns "43" for 43', () => {
     expect(fizzBuzz(43)).toBe("43");
   });

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
@@ -40,4 +40,8 @@ describe("fizzbuzz", () => {
   it('throws an error for numbers > 100', () => {
     expect(() => fizzBuzz(102)).toThrow();
   })
+
+  it('throws an error for numbers < 1', () => {
+    expect(() => fizzBuzz(-3)).toThrow(/Number argument should be between 1 and 100/);
+  })
 });

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
@@ -24,11 +24,11 @@ describe("fizzbuzz", () => {
     expect(fizzBuzz(3)).toBe('Fizz');
   });
 
-  it('return "Buzz" for 5', () => {
+  it('returns "Buzz" for 5', () => {
     expect(fizzBuzz(5)).toBe('Buzz');
   });
 
-  
+
 
 
 

--- a/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
+++ b/1_The_Physical/Guess_Point_Level_1_Stateless/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
@@ -1,5 +1,29 @@
+import { fizzBuzz } from "./fizzbuzz";
 
+/*
+Grading Checklist
+- I have committed on every single transition from red to green to refactor 
+- I have tests that validate the following statements 
+	-   _each return value is a string_ 
+	-   _3 returns "Fizz"_
+	-   _5 returns "Buzz_
+	-   _15 returns "FizzBuzz"_
+	-   _9 returns "Fizz"_
+	-   _43 returns "43"_
+	-   _42 returns "Fizz"_
+	-   _45 returns "FizzBuzz"_
+	-   _102 (you decide, throw an Error or handle some other way)_
+	-   _-12 (you decide, throw an Error or handle some other way)_
+	-   _any non-number (you decide, throw an Error or handle some other way)_
+- Once I have made the aforementioned tests pass, I have refactored my test specifications to use it.each() to perform parameterization ([see Tip #3 here](https://www.essentialist.dev/products/the-software-essentialist/categories/2152752280/posts/2166919573))
+- There is no duplication in my test code or my production code
+
+*/
 describe("fizzbuzz", () => {
+  it('returns "Fizz" for 3', () => {
+    expect(fizzBuzz(3)).toBe('Fizz');
+  });
 
+  
 
 });


### PR DESCRIPTION
- [X]  I have committed on every single transition from red to green to refactor 
- [X] I have tests that validate the following statements 
	-   [X] each return value is a string
	-   [X] 3 returns "Fizz"
	-   [X] 5 returns "Buzz
	-   [X] 15 returns "FizzBuzz"
	-   [X] 9 returns "Fizz"
	-   [X] 43 returns "43"
	-   [X] 42 returns "Fizz"
	-   [X] 45 returns "FizzBuzz"
	-   [X] 102 throws new Error('throws an error for numbers > 100')
	-   [X] -12 throws new Error('Number argument should be between 1 and 100')
	-   [X] any non-number (you decide, throw an Error or handle some other way)
- [X] Once I have made the aforementioned tests pass, I have refactored my test specifications to use it.each() to perform parameterization
- [X] There is no duplication in my test code or my production code